### PR TITLE
Remove placeholder when hidden

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -25,13 +25,13 @@
   content: attr(data-placeholder);
   color: #707684;
   font-weight: normal;
-  opacity: 0;
+  display: none;
 }
 
 .ce-header[contentEditable=true][data-placeholder]:empty::before {
-  opacity: 1;
+  display: block;
 }
 
 .ce-header[contentEditable=true][data-placeholder]:empty:focus::before {
-  opacity: 0;
+  display: none;
 }


### PR DESCRIPTION
When there is a placeholder but it's hidden (using `opacity: 0;`), it overlays the text and the text under the hidden placeholder is not selectable.