### PR TITLE
fix issue #57: when using placeholder, caret does not appear on first click

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -26,7 +26,7 @@
   color: #707684;
   font-weight: normal;
   display: none;
-  cursor: text;
+  pointer-events: none;
 }
 
 .ce-header[contentEditable=true][data-placeholder]:empty::before {


### PR DESCRIPTION
Fix for issue #57 

Replaced `cursor: text` with `pointer-event: none`

`cursor: text` is no longer needed, because the before-element is now completly ignored by the mouse