### PR TITLE
Fix Header Tool not supporting line breaks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -227,10 +227,14 @@ class Header {
    * @public
    */
   save(toolsContent) {
-    return {
-      text: toolsContent.innerHTML,
+    const sanitizerConfig = {
+      br: !(typeof this._settings.allowLineBreaks === 'undefined' || this._settings.allowLineBreaks === false),
+    }
+
+    return Object.assign({}, {
+      text: this.api.sanitizer.clean(toolsContent.innerHTML, sanitizerConfig),
       level: this.currentLevel.number,
-    };
+    });
   }
 
   /**
@@ -249,7 +253,9 @@ class Header {
   static get sanitize() {
     return {
       level: false,
-      text: {},
+      text: {
+        br: true,
+      },
     };
   }
 


### PR DESCRIPTION
## What's the issue?

Currently the Header Tool does not support line breaks like other Tools do. Normally a user can press Shift + Enter which adds a line break. However, this component strips them out.

This pull request fixes:

-  [#73 - Header not allowing `<br>` when shift+enter pressed - editor-js/header repo](https://github.com/editor-js/header/issues/73)
- [#1032 - show texts with line breaks, inside a block - editor-js repo](https://github.com/codex-team/editor.js/issues/1032#issuecomment-605503170)

## Solution

This pull request adds a config parameter `allowLineBreaks: {Boolean}`  that allows the developer to enable line breaks should they need.

```js
config: {
    allowLineBreaks: true, // default: false
}
```

By default, this is set to false.

