### PR TITLE
Add name to block tunes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -116,6 +116,7 @@ export default class Header {
   renderSettings() {
     return this.levels.map(level => ({
       icon: level.svg,
+      name: level.tag,
       label: this.api.i18n.t(`Heading ${level.number}`),
       onActivate: () => this.setLevel(level.number),
       closeOnActivate: true,


### PR DESCRIPTION
This way it has a `data-item-name` on the `.ce-popover-item` to identify the name of setting, which follows the structure of the default settings of editor.js (Move up, Delete, Move down).