### PR TITLE
Enable useStrictCSP for cssInjectedByJsPlugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,7 @@ You can select one of six levels for heading.
   }
 }
 ```
+
+## CSP support
+
+If you're using Content Security Policy (CSP) pass a `nonce` via [`<meta property="csp-nonce" content={{ nonce }} />`](https://github.com/marco-prontera/vite-plugin-css-injected-by-js#usestrictcsp-boolean) in your document head.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/header",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "keywords": [
     "codex editor",
     "header",

--- a/vite.config.js
+++ b/vite.config.js
@@ -19,5 +19,5 @@ export default {
     VERSION: JSON.stringify(VERSION),
   },
 
-  plugins: [cssInjectedByJsPlugin()],
+  plugins: [cssInjectedByJsPlugin({useStrictCSP: true})],
 };


### PR DESCRIPTION
Enables useStrictCSP when injecting styles. See https://github.com/marco-prontera/vite-plugin-css-injected-by-js#usestrictcsp-boolean

Does not throw any errors if meta property is not present

```useStrictCSP ? `elementStyle.nonce = document.head.querySelector('meta[property=csp-nonce]')?.content;` : ''```

Updated README to reflect the out of the box support