### PR TITLE
preserveBlank config param

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ All properties are optional.
 | placeholder  | `string`   | header's placeholder string |
 | levels       | `number[]` | enabled heading levels      |
 | defaultLevel | `number`   | default heading level       |
+| preserveBlank | `boolean` | (default: `false`) Whether or not to keep blank headers when saving editor data |
 
 ```javascript
 var editor = EditorJS({

--- a/src/index.js
+++ b/src/index.js
@@ -116,7 +116,6 @@ export default class Header {
   renderSettings() {
     return this.levels.map(level => ({
       icon: level.svg,
-      name: level.tag,
       label: this.api.i18n.t(`Heading ${level.number}`),
       onActivate: () => this.setLevel(level.number),
       closeOnActivate: true,

--- a/src/index.js
+++ b/src/index.js
@@ -116,6 +116,7 @@ export default class Header {
   renderSettings() {
     return this.levels.map(level => ({
       icon: level.svg,
+      name: level.tag,
       label: this.api.i18n.t(`Heading ${level.number}`),
       onActivate: () => this.setLevel(level.number),
       closeOnActivate: true,

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ import { IconH1, IconH2, IconH3, IconH4, IconH5, IconH6, IconHeading } from '@co
  * @property {string} placeholder — Block's placeholder
  * @property {number[]} levels — Heading levels
  * @property {number} defaultLevel — default level
+ * @property {boolean} preserveBlank - Whether or not to keep blank headers when saving editor data
  */
 
 /**
@@ -160,7 +161,11 @@ export default class Header {
    * @public
    */
   validate(blockData) {
-    return blockData.text.trim() !== '';
+    if (blockData.text.trim() === '' && !this.preserveBlank) {
+      return false;
+    }
+
+    return true;
   }
 
   /**
@@ -397,6 +402,17 @@ export default class Header {
     return this._settings.levels ? availableLevels.filter(
       l => this._settings.levels.includes(l.number)
     ) : availableLevels;
+  }
+
+  /**
+   * Get preserveBlank
+   *
+   * @returns {preserveBlank}
+   */
+  get preserveBlank() {
+    let preserveBlank = this._settings.preserveBlank || false;
+
+    return preserveBlank;
   }
 
   /**


### PR DESCRIPTION
Added a `preserveBlank` configuration parameter to determine whether blank headers should be kept when saving editor data, similar to the `editorjs/paragraph` block.