### PR TITLE
Fix issue of undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/header",
-  "version": "2.8.3",
+  "version": "2.8.4",
   "keywords": [
     "codex editor",
     "header",

--- a/src/index.ts
+++ b/src/index.ts
@@ -152,7 +152,7 @@ export default class Header {
     }
 
     newData.text = data.text || '';
-    newData.level = parseInt(data.level.toString()) || this.defaultLevel.number;
+    newData.level = data && data.level? parseInt(data.level.toString()) : this.defaultLevel.number;
 
     return newData;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,11 +148,11 @@ export default class Header {
     const newData: HeaderData = {text: '', level: this.defaultLevel.number };
 
     if (typeof data !== 'object') {
-      data = {} as HeaderData;
+      data = {text: '', level: this.defaultLevel.number};
     }
 
     newData.text = data.text || '';
-    newData.level = data && data.level? parseInt(data.level.toString()) : this.defaultLevel.number;
+    newData.level = parseInt(data.level.toString()) || this.defaultLevel.number;
 
     return newData;
   }


### PR DESCRIPTION
## Problem:
An issue of reading undefined by `toString`.

## Cause:
The issue occurs in `nomalizeData` function, when the data is not of type object, it gets an empty object.

## Solution:
There are two solutions for this;
- If type of data is not object, it can be filled with default value, as `newData`.
- Check on `data` and `data.level` content before accessing the object. (This one was implemented)