### PR TITLE
fix(normalzeData): convert current line to heading fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "@editorjs/header",
-  "version": "2.8.6",
+  "version": "2.8.7",
   "keywords": [
     "codex editor",
     "header",
+    "heading",
     "editor.js",
     "editorjs"
   ],
-  "description": "Header Tool for Editor.js",
+  "description": "Heading Tool for Editor.js",
   "license": "MIT",
   "repository": "https://github.com/editor-js/header",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,7 +144,7 @@ export default class Header {
    * @private
    */
   isHeaderData(data: any): data is HeaderData {
-    return (data as HeaderData).text !== undefined && (data as HeaderData).level !== undefined;
+    return (data as HeaderData).text !== undefined;
   }
 
   /**
@@ -158,12 +158,13 @@ export default class Header {
   normalizeData(data: HeaderData | {}): HeaderData {
     const newData: HeaderData = { text: '', level: this.defaultLevel.number };
 
-    if (!this.isHeaderData(data)) {
-      return { text: '', level: this.defaultLevel.number};
+    if (this.isHeaderData(data)) {
+      newData.text = data.text || '';
+  
+      if (data.level !== undefined && !isNaN(parseInt(data.level.toString()))) {
+        newData.level = parseInt(data.level.toString());
+      }
     }
-
-    newData.text = data.text || '';
-    newData.level = parseInt(data.level.toString()) || this.defaultLevel.number;
 
     return newData;
   }


### PR DESCRIPTION
## Problem
The data get removed when converting a line content into heading. Issue #114 

## Cause
The normalizeData function requires both data.text and data.level to be present for the data to be considered valid. If data.level is missing, the entire content, including data.text, is discarded and default values are used.

## Solution
Modify the normalizeData function to retain data.text even if data.level is missing. Assign data.level to a default value (this.defaultLevel.number) if it is not provided or invalid. This ensures that valid text content is preserved even when the level is missing.